### PR TITLE
Display read-only posts when not authed

### DIFF
--- a/src/components/NoAuthAppViews.js
+++ b/src/components/NoAuthAppViews.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { Nav } from "./nav/Nav";
+import { Route } from "react-router-dom";
+import "./Rare.css";
+import { PostProvider } from "./posts/PostProvider";
+import { CategoryProvider } from "./categories/CategoryProvider";
+import { PostList } from "./posts/PostList";
+import { CategoryButtonList } from "./categories/CategoryButtonList";
+
+export const NoAuthAppViews = (props) => {
+
+    return (
+        <>
+            <main className="main-container" style={{ margin: "0 0", lineHeight: "1.75rem", }}>
+
+            <Route path="/" render={(props) => (
+                    <nav className="cont--nav">
+                        <Nav {...props} />
+                    </nav>)} />
+
+                <CategoryProvider>
+                    <PostProvider>
+                        <>
+                            <Route exact path="/" render={(props) => (
+                                <>
+                                    <div className="main-wrap">
+                                        <div className="top-spacer"></div>
+                                        <div className="mid-section">
+                                            <div className="left-main">
+                                                <PostList {...props}></PostList>
+
+                                            </div>
+                                            <div className="divider"></div>
+                                            <div className="right-main">
+                                                <CategoryButtonList
+                                                    {...props} />
+                                    </div>
+                                        </div>
+                                        <div className="bottom-spacer"></div>
+                                    </div>
+                                </>
+                            )} />
+                        </>
+                    </PostProvider>
+                </CategoryProvider>
+
+            </main>
+        </>
+    )};

--- a/src/components/Rare.js
+++ b/src/components/Rare.js
@@ -3,6 +3,7 @@ import { Route, Redirect } from "react-router-dom"
 import { ApplicationViews } from "./ApplicationViews"
 import { Login } from "./auth/Login"
 import { Register } from "./auth/Register"
+import { NoAuthAppViews } from "./NoAuthAppViews"
 import "./Rare.css"
 
 export const Rare = () => (
@@ -19,7 +20,13 @@ export const Rare = () => (
                 )
             }
             else {
-                return <Redirect to="/login" />
+                return (
+                    <>
+                    <Route render={props =>
+                        <NoAuthAppViews
+                        {...props}  />} />
+                    </>
+                )
             }
         }} />
 

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -18,6 +18,12 @@ export const Nav = (props) => {
         }
     }
 
+    const checkAuth = () => {
+        if (localStorage.getItem("rare_user_id")) {
+            return true
+    } return false
+}
+
     useEffect(()=>{
         if(localStorage.getItem("rare_user_id") !== null){
             setLoggedIn(true)
@@ -49,11 +55,16 @@ export const Nav = (props) => {
                     <div className="top-space"></div>
                     <div className="link nav__link wrapper__nav--right">
                         <div className="nav__link-wrapper post-wrapper">
-                            <Link
-                            className="link nav__link posts-link"
-                            to="/">
-                                posts
-                            </Link>
+                            {
+                                checkAuth() ?
+                                <Link
+                                    className="link nav__link posts-link"
+                                    to="/">
+                                    posts
+                                </Link>
+                                : null
+                            }
+                            
                         </div>
                         {loggedIn
                         ?

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -7,6 +7,11 @@ import "./Post.css";
 
 export const PostList = (props) => {
     const {posts, getPosts} = useContext(PostContext)
+    const checkAuth = () => {
+        if (localStorage.getItem("rare_user_id")) {
+            return true
+    } return false
+}
 
     useEffect(() => {
         getPosts()
@@ -16,11 +21,15 @@ export const PostList = (props) => {
         <>
         <div className="mainPostContainer">
             <h2>Posts</h2>
-            <button
-                    className="btn newPostbtn"
-                    onClick={() => {
+            {
+                checkAuth() ?
+                    <button
+                        className="btn newPostbtn"
+                        onClick={() => {
                         props.history.push(`/new_post/`)
                     }}>Create New Post</button>
+                    : null
+                }
             {
                 posts !== [] ? posts.map(p => {
                     return <div key={p.id}>
@@ -28,9 +37,17 @@ export const PostList = (props) => {
                             <p>{p.user.display_name}</p>
                             <p style={{ marginLeft: '.5rem' }} >• {new Date(p.publication_date).toDateString()}</p>
                         </div>
-                        <Link className="postLink" to={{pathname:`/posts/${p.id}`}}>
+                        {
+                checkAuth() ?
+                    <Link className="postLink" to={{pathname:`/posts/${p.id}`}}>
                         <p>{p.title}</p>
-                        </Link>
+                    </Link>
+                    : 
+                    <Link className="postLink" to={{pathname:`/login`}}>
+                        <p>{p.title}</p>
+                    </Link>
+                }
+                        
                         <p>Posted in <b>{p.category.category}</b></p>
                     </div>
                 }) : null

--- a/src/components/posts/PostTags/PostTags.js
+++ b/src/components/posts/PostTags/PostTags.js
@@ -14,6 +14,10 @@ export const PostTags = ({postId}) => {
         getPostTagsByPost(postId)
     }, [postId, postTagIds]);
 
+    useEffect(() => {
+        getTags()
+    }, [])
+
     const toggleEdit = () => {
         setIsEditing(!isEditing)
         isEditing ? getTags() : getPostTagsByPost(postId)


### PR DESCRIPTION
### NEEDS REVIEW !! Login page formatting has been modified by alterations in this PR

#### Changes Made
1. Added NoAuthAppView.js
2. Modified Rare.js to redirect to NoAuthAppView.js if not authed
3. NoAuthAppview.js only loads components necessary to view post list and filter categories
4. Navbar is modified to display a link to log in
5. PostList.js is modified to hide button for creating posts and redirect to login on post title click if unauthed
​
#### Steps to Review
1. Checkout this branch locally and run the application.
```
git fetch --all
git checkout ap-post-auth
```
2. Run the application.
```
npm start
```
3. Open a new Terminal tab (⌘T) and navigate to the server directory.
```
..
server
```
4. Initialize virtual environment, and run the server.
```
pipenv shell
watchgod request_handler.main
```
5. Test app functionality. 
> When user logs out, they should still see the list of posts, minus the Create Post button
> On click of post title, user should be redirected to login form
> User should also see link to login form on navbar
> No components aside from modified nav and post list should be accessible to unauthed user
> Authed users should see no change in functionality