### PR TITLE
CB User Active Status

### DIFF
--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -5,7 +5,17 @@ import "./User.css"
 
 export const User = (props) => {
 
-    const { changeUserType } = useContext(UserContext)
+    const { changeUserType, changeUserActive } = useContext(UserContext)
+
+    const statusPrompt = (id) => {
+        let prompt = window.confirm("Are you sure you want to change this user's account status?");
+        if( prompt === true ) {
+            changeUserActive(id)
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     return (
         <>
@@ -24,7 +34,7 @@ export const User = (props) => {
                     </Link>
                 </td>
                 <td className="userInfo"><label>
-                        <input type="checkbox" id="userRadio" checked={props.user.is_active} ></input>
+                        <input type="checkbox" id="userRadio" checked={props.user.is_active} onChange={() => statusPrompt(props.user.id)} ></input>
                         Active
                     </label>
                 </td>

--- a/src/components/users/UserProvider.js
+++ b/src/components/users/UserProvider.js
@@ -39,10 +39,21 @@ export const UserProvider = (props) => {
             .then(getUsers)
     }
 
+    const changeUserActive = (userId) => {
+        return fetch(`http://localhost:8000/users/${userId}/change_active`, {
+            method: "PATCH",
+            headers: {
+                "Authorization": `Token ${localStorage.getItem("rare_token")}`,
+                "Content-Type": "application/json"
+            },
+        })
+            .then(getUsers)
+    }
+
 
     return (
         <UserContext.Provider value={{
-            users, getUsers, currentUser, getCurrentUser, changeUserType
+            users, getUsers, currentUser, getCurrentUser, changeUserType, changeUserActive
         }}>
             {props.children}
         </UserContext.Provider>


### PR DESCRIPTION
…added ability to toggle active accountsbut will be prompted with an alert when doing so

#### Changes Made
1. added `changeUserActive` method to user provider
2. put that method on an onChange event, along with a prompt, in the radio button for user manager active option

#### Steps to Review
1. Checkout this branch locally and run the application.
```
git fetch --all
git checkout cb-deactivate-user
```
2. Run the application.
```
npm start
```
3. Initialize virtual environment, and run the server.
```
pipenv shell
python manage.py server
```
4. Test app functionality.
> When user runs both React and Django servers and is logged in as an admin, the user should be able to visit the user manager page and toggle users between active and not active
> When you do so you should receive a prompt that asks if you are sure. if you select yes, the change should be carried out and if no then no change should be made. 
> logout, then try to log in as the account that you deactivated. you shouldn't be able to
> log back in as an admin, then reactivate the previous account. you should now be able to login under the previous account
5. View code file.
> Confirm file modifications are present as indicated above.
> Confirm no unused code or extraneous comments exist.